### PR TITLE
Support multithreaded access to a single client

### DIFF
--- a/test/functional/thread-test.py
+++ b/test/functional/thread-test.py
@@ -42,14 +42,20 @@ j = JujuClient(url='wss://' + wss_ip, password=jpass)
 j.login()
 
 def loop_on_status(j, i):
-    print("thread {} starting".format(i))
+    print("{} starting: {}".format(i, threading.current_thread().name))
     if i == 0:
         time.sleep(3)
+        print("*"*80)
+        print("{} RECONNECT {}\n".format(i, threading.current_thread().name))
         j.reconnect()
+        time.sleep(5)
+        j.reconnect()
+        print("*"*80)
+        print("{} RECONNECT {}\n".format(i, threading.current_thread().name))
         
     for idx in range(30):
         machines = j.status()['Machines']
-        print("{} ".format(i), end="", flush=True)
+        print("{} ".format(i), end="")#, flush=True)
         #sleeptime = 1 * ((i+1) * 0.1)
         sleeptime = 0.1
         time.sleep(sleeptime)
@@ -61,7 +67,8 @@ threads = [threading.Thread(target=loop_on_status, args=(j, i))
            for i in range(NTHREADS)]
 for thread in threads:
     thread.start()
-    
+
 for thread in threads:
     thread.join()
+
 print('done')

--- a/test/functional/thread-test.py
+++ b/test/functional/thread-test.py
@@ -1,0 +1,67 @@
+#!python3
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from getpass import getpass
+
+from macumba import JujuClient
+import yaml
+from glob import glob
+import os
+import sys
+import time
+import threading
+
+juju_home = os.getenv("JUJU_HOME", "~/.juju")
+jenv_pat = os.path.expanduser(os.path.join(juju_home, "environments/*.jenv"))
+jenv_files = glob(jenv_pat)
+if len(jenv_files) == 0 or len(jenv_files) > 1:
+    print("found 0 or >1 .jenv files, will ask for IP and password")
+    wss_ip = input("juju api IP (with port):")
+    jpass = getpass("juju password : ")
+else:
+    env = yaml.load(open(jenv_files[0]))
+    wss_ip = env['state-servers'][0]
+    jpass = env['password']
+
+print('Connecting using wss ip ' + wss_ip)
+j = JujuClient(url='wss://' + wss_ip, password=jpass)
+
+j.login()
+
+def loop_on_status(j, i):
+    print("thread {} starting".format(i))
+    if i == 0:
+        time.sleep(3)
+        j.reconnect()
+        
+    for idx in range(30):
+        machines = j.status()['Machines']
+        print("{} ".format(i), end="", flush=True)
+        #sleeptime = 1 * ((i+1) * 0.1)
+        sleeptime = 0.1
+        time.sleep(sleeptime)
+        assert len(machines) > 0
+    print("thread {} done".format(i), flush=True)
+
+NTHREADS = int(sys.argv[1])
+threads = [threading.Thread(target=loop_on_status, args=(j, i))
+           for i in range(NTHREADS)]
+for thread in threads:
+    thread.start()
+    
+for thread in threads:
+    thread.join()
+print('done')


### PR DESCRIPTION
Adds a recursive lock around all accesses to the websocket connection and the request id.

It's not a fine-grained lock, call() has a pair of send and receive, and it holds the lock while it waits.
However, to ensure progress, receives now time out after two seconds.

to test, try the test script from commit 1233d6f without the fixes, to see that reconnection in one thread causes errors in other threads. (run it with one command line arg, the number of threads).
With the locking, the test script should never print errors.

(NOTE - if you've already got macumba installed, make sure you're using the right PYTHONPATH. use the installed version to look for the bug and then set PYTHONPATH=path-to-srctree/macumba to check the fix )
